### PR TITLE
Added an option to use quadrupole expansions of mass

### DIFF
--- a/src/pytreegrav/octree.py
+++ b/src/pytreegrav/octree.py
@@ -8,6 +8,7 @@ spec = [
     ('Deltas', float64[:]), # distance between COM and geometric center of node
     ('Coordinates', float64[:,:]), # location of center of mass of node (actually stores _geometric_ center before we do the moments pass)
     ('Masses', float64[:]), # total mass of node
+    ('Quadrupoles', float64[:,:,:]), # Quadrupole moment of the node
     ('NumParticles', int64), # number of particles in the tree
     ('NumNodes',int64), # number of particles + nodes (i.e. mass elements) in the tree
     ('Softenings', float64[:]), # individual softenings for particles, _maximum_ softening of inhabitant particles for nodes
@@ -31,18 +32,18 @@ octant_offsets = 0.25 * np.array([[-1,-1,-1],
 class Octree(object):
     """Octree implementation."""
 
-    def __init__(self, points, masses, softening, morton_order=True):
+    def __init__(self, points, masses, softening, morton_order=True, quadrupole=False):
         self.TreewalkIndices = -ones(points.shape[0],dtype=np.int64)        
         children = self.BuildTree(points, masses, softening) # first provisional treebuild to get the ordering right
         SetupTreewalk(self,self.NumParticles,children) # set up the order of the treewalk
-        ComputeMoments(self,self.NumParticles,children) # compute centers of mass, etc.         
+        ComputeMoments(self,self.NumParticles,children,quadrupole) # compute centers of mass, etc.         
         self.GetWalkIndices() # get the Morton ordering of the points
  
         if morton_order: # if enabled, we rebuild the tree in Morton order (the order that points are visited in the depth-first traversal)
             children = self.BuildTree(points[self.TreewalkIndices], np.take(masses,self.TreewalkIndices), np.take(softening,self.TreewalkIndices)) # now re-build the tree with everything in order
             SetupTreewalk(self,self.NumParticles,children) # re-do the treewalk order with the new indices
 
-        ComputeMoments(self,self.NumParticles,children) # compute centers of mass, etc.
+        ComputeMoments(self,self.NumParticles,children,quadrupole) # compute centers of mass, etc.
             
     def BuildTree(self,points,masses,softening):
         # initialize all attributes
@@ -51,6 +52,7 @@ class Octree(object):
         self.Sizes = zeros(self.NumNodes)
         self.Deltas = zeros(self.NumNodes)
         self.Masses = zeros(self.NumNodes)
+        self.Quadrupoles = zeros((self.NumNodes,3,3)) # No need to initialize this beyond zero, all n>0 moments are 0 for a single particle
         self.Softenings = zeros(self.NumNodes)
         self.Coordinates = zeros((self.NumNodes,3))
         self.Deltas = zeros(self.NumNodes)
@@ -128,21 +130,29 @@ class Octree(object):
                 no = self.FirstSubnode[no]
 
 @njit
-def ComputeMoments(tree, no, children): # does a recursive pass through the tree and computes centers of mass, total mass, max softening, and distance between geometric center and COM
+def ComputeMoments(tree, no, children, quadrupole): # does a recursive pass through the tree and computes centers of mass, total mass, max softening, and distance between geometric center and COM
     if no < tree.NumParticles: # if this is a particle, just return the properties
-        return tree.Softenings[no], tree.Masses[no], tree.Coordinates[no] 
+        return tree.Softenings[no], tree.Masses[no], tree.Quadrupoles[no], tree.Coordinates[no]
     else:
         m = 0
         com = zeros(3)
         hmax = 0
         for c in children[no]:
             if c > -1:
-                hi, mi, comi = ComputeMoments(tree,c,children)
+                hi, mi, quadi, comi = ComputeMoments(tree,c,children,quadrupole)
                 m += mi
                 com += mi*comi
                 hmax = max(hi, hmax)
         tree.Masses[no] = m
         com = com/m
+        quad = zeros((3,3))
+        if quadrupole:
+            for c in children[no]:
+                if c > -1:
+                    hi, mi, quadi, comi = ComputeMoments(tree,c,children,quadrupole)
+                    ri = comi-com
+                    quad += quadi + mi * (3*np.outer(ri,ri) - np.linalg.norm(ri)*np.ones((3,3))) # Calculate the quadrupole moment based on the moments of the subcells
+        tree.Quadrupoles[no] = quad
         delta = 0
         for dim in range(3):
             dx = com[dim] - tree.Coordinates[no,dim]
@@ -150,7 +160,7 @@ def ComputeMoments(tree, no, children): # does a recursive pass through the tree
         tree.Deltas[no] = np.sqrt(delta)
         tree.Coordinates[no] = com
         tree.Softenings[no] = hmax
-        return hmax, m, com
+        return hmax, m, quad, com
 
 @njit            
 def SetupTreewalk(tree,no,children):

--- a/src/pytreegrav/treewalk.py
+++ b/src/pytreegrav/treewalk.py
@@ -37,6 +37,8 @@ def PotentialWalk(pos,  tree, softening=0, no=-1, theta=0.7):
             no = tree.NextBranch[no]
         elif r > max(tree.Sizes[no]/theta + tree.Deltas[no], h+tree.Sizes[no]*0.6+tree.Deltas[no]): # if we satisfy the criteria for accepting the monopole
             phi -= tree.Masses[no]/r
+            if tree.HasQuads:
+                phi -= 0.5 * np.dot(np.dot(dx,tree.Quadrupoles[no]),dx)/(r*r*r*r*r) # Potential from the quadrupole moment
             no = tree.NextBranch[no]
         else: # open the node
             no = tree.FirstSubnode[no]
@@ -81,6 +83,8 @@ def AccelWalk(pos,  tree, softening=0, no=-1, theta=0.7): #,include_self_potenti
             no = tree.NextBranch[no]
         elif r > max(tree.Sizes[no]/theta + tree.Deltas[no], h+tree.Sizes[no]*0.6+tree.Deltas[no]): # if we satisfy the criteria for accepting the monopole            
             fac = tree.Masses[no]/(r*r2)
+            if tree.HasQuads:
+                g -= np.dot(tree.Quadrupoles[no], dx/r)/(r*r*r*r) - 2.5*np.dot(dx/r, np.dot(tree.Quadrupoles[no], dx/r))*dx/(r*r*r*r*r)
             sum_field = True
             no = tree.NextBranch[no] # go to the next branch in the tree
         else: # open the node


### PR DESCRIPTION
I've been playing around with some old classic treecode papers, and pytreegrav has been really handy for that!  Thanks @mikegrudic and everyone else who helped write this code.  I added an option in the `Octree` class & methods to use a quadrupole expansion, rather than just the n=0 monopole.  Naturally, this gives slightly more accurate potentials and accelerations for the same opening angle, but with the added cost of storing the moment tensors and calculating them when the tree is built.  I haven't really done much optimizing, so it may not be the most efficient implementation possible.  I may extend this to higher-order moments some time as well.