### PR TITLE
release 1.2.0; declare runtime dependencies for real

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,27 @@
-import setuptools, os
+import setuptools
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-thelibFolder = os.path.dirname(os.path.realpath(__file__))
-requirementPath = thelibFolder + "/requirements.txt"
-install_requires = []
-if os.path.isfile(requirementPath):
-    with open(requirementPath) as f:
-        install_requires = f.read().splitlines()
+# Runtime dependencies, stated here rather than read from requirements.txt. `python -m build`
+# builds the wheel from the sdist, requirements.txt was never in the sdist (there is no
+# MANIFEST.in), so the file read silently produced an empty list and every release so far has
+# shipped with no declared dependencies at all -- check requires_dist on PyPI for 1.1.4.
+#
+# requirements.txt stays as the dev/CI list; it is not the same set. healpy and pyerfa appear
+# there but are imported nowhere in the package, and pytest is test-only.
+#
+# numba>=0.57 is a hard floor: treewalk and grouped_treewalk import parallel_chunksize at module
+# scope, which was added in 0.57, so anything older fails at import rather than at use.
+install_requires = [
+    "numpy",
+    "numba>=0.57",
+    "scipy",  # scipy.spatial.transform.Rotation, used to build the ray grid in treewalk
+]
 
 setuptools.setup(
     name="pytreegrav",
-    version="1.1.6",
+    version="1.2.0",
     author="Mike Grudic",
     author_email="mike.grudich@gmail.com",
     description="Fast approximate gravitational force and potential calculations",


### PR DESCRIPTION
Version 1.1.6 was set locally but never published; PyPI's latest is 1.1.4. Going to 1.2.0 rather than 1.1.5/1.1.6 because this is not a patch release: the non-unique-position warning moved after the build and no longer false-positives on lattices, the adaptive bruteforce/tree threshold dropped 8000 -> 4000, and the moments rollup reassociates its sums so results move at ~1e-13. Alongside a ~12x faster tree build and fixes for a DynamicOctree segfault, a hang on duplicate particles at the origin, and a README example that had been broken since a keyword rename.

Also fixes packaging. install_requires was read from requirements.txt at build time, but `python -m build` builds the wheel from the sdist and requirements.txt was never in the sdist -- there is no MANIFEST.in -- so the read silently produced an empty list. Every release so far has shipped with no declared dependencies whatsoever; requires_dist is null for 1.1.4 on PyPI. `pip install pytreegrav` into a clean environment pulls no numpy, numba or scipy and fails on import. Users only got away with it because the audience already has them.

Dependencies are now stated in setup.py directly, and are the ones actually imported: numpy, numba, scipy. requirements.txt stays as the dev/CI list and is deliberately a different set -- healpy and pyerfa are listed there but imported nowhere in the package, and pytest is test-only, so none of the three belong in install_requires.

numba>=0.57 is a hard floor rather than a guess: treewalk and grouped_treewalk import parallel_chunksize at module scope and it landed in 0.57, so older numba fails at import rather than at use.

Verified by installing the built wheel alone into an isolated venv (no PYTHONPATH, no user site) and letting pip resolve from the wheel metadata: it pulled numpy 2.4.6, numba 0.66.0, scipy 1.18.0, and the full suite passes against the installed package, 67 passed 1 xfailed, plus a smoke test covering tree, bruteforce, quadrupole and ColumnDensity.