### PR TITLE
release 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {"cuda": ["numba-cuda>=0.30"]}
 
 setuptools.setup(
     name="pytreegrav",
-    version="1.2.0",
+    version="1.3.0",
     author="Mike Grudic",
     author_email="mike.grudich@gmail.com",
     description="Fast approximate gravitational force and potential calculations",


### PR DESCRIPTION
Optional CUDA backend for ray-traced column density (pytreegrav.cuda, ColumnDensity(device="cuda"), pip install pytreegrav[cuda]), grouped column-density walks, and the column-density bugfixes.

Backwards compatible in API, but one output change worth knowing about: ColumnDensity(rays=None) now groups targets by default, which opens a superset of nodes and splits each node's mass across the sky bins more finely. The answer shifts by 2-4% rms and is more accurate -- on a glass sphere the bin-to-bin scatter nearly halves. group_size=1 recovers the previous result exactly.