### PR TITLE
correct the CUDA accuracy and speedup claims with real-data measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,10 +221,25 @@ NH_eff = Σ_eff X_H / m_p  # column density in H nuclei code length^-2
 
 ## GPU-accelerated ray-tracing (optional)
 
-The ray-traced path has an optional CUDA backend, measured at **11.8x / 15.1x / 18.2x** over the
-parallel CPU walk at N = 1e5 / 1e6 / 3e6 on an RTX A6000 against 32 Xeon Gold 6244 threads. It is
-single precision, so expect ~1e-5 relative error rather than the CPU path's ~1e-15 — far below the
-error of the uniform-sphere density model itself, but not interchangeable with it.
+The ray-traced path has an optional CUDA backend. On an RTX A6000 against 32 Xeon Gold 6244 threads
+it is **7.9x** faster on a real STARFORGE snapshot (24.7M gas particles, 6 rays, 148M walks), and
+11.8–18.2x on smooth synthetic clouds at N = 1e5–3e6. Clustered data is the harder case: a warp can
+hold both dense-core and diffuse-gas sightlines, so lanes wait on each other, and the tree no longer
+fits in cache. Take ~8x as the figure to expect on production data.
+
+It is single precision, and on real data the error grows with the number of contributions summed
+along a sightline, so it is a distribution rather than one number. Measured over 12M sightlines of
+that snapshot, against the float64 CPU result:
+
+| median | p99 | p99.9 | p99.99 | max |
+| --- | --- | --- | --- | --- |
+| 2.0e-6 | 4.4e-5 | 1.7e-4 | 9.1e-4 | 2.5e-2 |
+
+The worst cases are the *densest* sightlines — 0.009% of entries exceed 1e-3, and their median column
+is 240x the overall median. Those are the ones where τ ≫ 1 and the answer is "opaque" regardless, so
+this is comfortably below the error of the uniform-sphere density model itself. But the CPU path
+agrees with direct summation to ~1e-15, so the two are not interchangeable if you need reproducible
+digits.
 
 ```
 pip install pytreegrav[cuda]     # adds numba-cuda; nothing changes for CPU-only users

--- a/docs/source/cuda_API.rst
+++ b/docs/source/cuda_API.rst
@@ -3,13 +3,52 @@
 GPU-accelerated ray-tracing
 ===========================
 
-The ray-traced column density path has an optional CUDA backend. It is measured at **11.8x / 15.1x /
-18.2x** over the parallel CPU walk at :math:`N = 10^5 / 10^6 / 3 \times 10^6`, on an NVIDIA RTX A6000
-against 32 Xeon Gold 6244 threads.
+The ray-traced column density path has an optional CUDA backend, benchmarked on an NVIDIA RTX A6000
+against 32 Xeon Gold 6244 threads:
 
-It is single precision, so expect a relative error around :math:`10^{-5}` rather than the CPU path's
-:math:`10^{-15}`. That is far below the error of the uniform-sphere density model the estimator is
-built on, but the two are not interchangeable if you need reproducible last digits.
+.. list-table::
+   :header-rows: 1
+
+   * - problem
+     - speedup
+   * - STARFORGE snapshot, 24.7M gas particles, 6 rays (148M walks)
+     - **7.9x**
+   * - smooth synthetic clouds, :math:`N = 10^5` / :math:`10^6` / :math:`3 \times 10^6`
+     - 11.8x / 15.1x / 18.2x
+
+Expect the former on production data. Clustered structure is the harder case for a GPU: a warp can
+hold both dense-core and diffuse-gas sightlines at once, so lanes wait on each other, and at 24.7M
+particles the packed tree is 1.5 GB against a 6 MB L2.
+
+Accuracy
+--------
+
+The kernel is single precision. On real data the error grows with the number of contributions summed
+along a sightline, so it is a distribution rather than a single figure. Measured over 12M sightlines
+of that snapshot against the float64 CPU result:
+
+.. list-table::
+   :header-rows: 1
+
+   * - median
+     - p99
+     - p99.9
+     - p99.99
+     - max
+   * - 2.0e-6
+     - 4.4e-5
+     - 1.7e-4
+     - 9.1e-4
+     - 2.5e-2
+
+The largest errors fall on the *densest* sightlines: 0.009% of entries exceed :math:`10^{-3}`, and
+their median column density is 240x the overall median. Those are precisely the sightlines where
+:math:`\tau \gg 1` and the answer is "opaque" whatever the last digits say, so this sits comfortably
+below the error of the uniform-sphere density model the estimator is built on.
+
+Note the CPU path agrees with direct summation to :math:`\sim 10^{-15}`, so the two are not
+interchangeable if you need reproducible digits. Smooth test problems will understate the spread
+above by three orders of magnitude, because they have almost no dynamic range in column density.
 
 Installation
 ------------

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -72,8 +72,8 @@ and by importing the pytreegrav Python frontend in Python
 Optional: GPU acceleration
 --------------------------
 
-The ray-traced column density path has an optional CUDA backend, roughly 12-18x faster than the
-parallel CPU walk. Install the extra with
+The ray-traced column density path has an optional CUDA backend, roughly 8x faster than the parallel
+CPU walk on clustered production data (up to 18x on smooth test problems). Install the extra with
 
 .. code-block:: bash
 

--- a/experiments/gpu/README.md
+++ b/experiments/gpu/README.md
@@ -282,9 +282,52 @@ All JIT paths warmed first; `build` and `pack+upload` are one-off per tree.
 | 1e6 | 160 ms | 179 ms | 7643 ms | **507 ms** | **15.1x** | 8.4e-06 |
 | 3e6 | 486 ms | 511 ms | 40659 ms | **2230 ms** | **18.2x** | 8.0e-06 |
 
-**Clears the 10x criterion**, and the margin grows with N -- there is more work to fill 84 SMs with,
-while the CPU is increasingly cache-limited (its cost goes as N^(4/3)). Note the CPU number at N=3e6
-is 41 s, which is the scaling this was meant to attack.
+**Clears the 10x criterion**, and on these smooth clouds the margin grows with N -- more work to fill
+84 SMs, while the CPU is increasingly cache-limited (its cost goes as N^(4/3)). But see the real-data
+section below: this trend does *not* survive contact with clustered structure.
+
+### Real data: 7.9x, not 18x
+
+STARFORGE `v1.0/M2e4_R10_S0_T1_B0.01_Res271_n2_sol0.5_42/output/snapshot_500.hdf5` — 24.7M gas
+particles, 2.47e4 Msun over 100 pc, `h` spanning 1.5e-4 to 1.87 pc:
+
+| | time | per particle |
+| --- | --- | --- |
+| tree build (37.05M nodes) | 4.1 s | |
+| pack + upload (1482 MB) | 4.9 s | |
+| CUDA, 6 rays (148.2M walks) | **106.7 s** | 4.32 us |
+| CPU, 32 threads | **847.2 s** | 34.30 us |
+| | **7.94x** | |
+
+Less than half the synthetic figure. Per-particle GPU cost rose 5.8x from N=3e6 synthetic to N=2.47e7
+real, while the CPU's rose only 2.5x. Two causes, both absent from a Gaussian cloud: the GPU carries a
+2.1 GB working set (1482 MB tree + 593 MB output) against a 6 MB L2, and with 8.7e8 of dynamic range
+in column density a single warp can hold both dense-core and diffuse-gas sightlines, so lanes wait on
+each other. **Quote ~8x for production data, not the synthetic numbers.**
+
+A 2M-target subsample of the same tree gives 13.0x, but that number should be discarded: striding the
+Morton order inflates the CPU grouped walk's group extents, which handicaps the CPU rather than
+revealing anything about the GPU.
+
+Both float32 hazards were checked on this data and are comfortable: `span/h_min` = 6.6e5 against
+float32's ~1.7e7 of resolution, and the largest leaf prefactor `3M/(4 pi h^2)` is 1.05e4 against a
+3.4e38 ceiling, so the packer's overflow guard never fires.
+
+### float32 error on real data is a distribution, not a number
+
+Over 12M nonzero sightlines, against the float64 CPU result:
+
+| median | p99 | p99.9 | p99.99 | max |
+| --- | --- | --- | --- | --- |
+| 1.99e-06 | 4.41e-05 | 1.66e-04 | 9.13e-04 | 2.53e-02 |
+
+It tracks column magnitude — bottom decile max 1.0e-04, top decile max 2.5e-02 — because error
+accumulates with the number of contributions summed (the sqrt(N) growth the brute-force kernel showed
+above). 1,090 of 12M entries (0.0091%) exceed 1e-03; their median column is 5.3e3 against 22.5
+overall, i.e. they are the *densest* sightlines, carrying 2.87% of the total column. Those are exactly
+where tau >> 1 and the answer is "opaque" regardless, so this is harmless in practice — but the smooth
+benchmarks reported ~8e-06 uniformly and understate the tail by three orders of magnitude. Any
+accuracy claim for this kernel should come from data with realistic dynamic range.
 
 Secondary measurements:
 

--- a/src/pytreegrav/cuda.py
+++ b/src/pytreegrav/cuda.py
@@ -10,10 +10,16 @@ uploaded tree::
 
 or take the single-shot path, ``ColumnDensity(..., device="cuda")``, which pays the upload each time.
 
-Measured on an RTX A6000 against the shipped grouped CPU walk on 32 Xeon Gold 6244 threads:
-11.8x / 15.1x / 18.2x at N = 1e5 / 1e6 / 3e6, with float32 error ~8e-06.  The kernel compiles to 38
-registers and zero local memory -- 100% occupancy -- because the walk is stackless: its entire state
-is one integer cursor threaded through NextBranch/FirstSubnode.
+Measured on an RTX A6000 against the shipped grouped CPU walk on 32 Xeon Gold 6244 threads: **7.9x**
+on a real STARFORGE snapshot (24.7M gas particles, 6 rays), and 11.8x / 15.1x / 18.2x on smooth
+synthetic clouds at N = 1e5 / 1e6 / 3e6.  Expect the former; clustered data puts dense-core and
+diffuse-gas sightlines in one warp, so lanes wait on each other, and the 1.5 GB packed tree swamps a
+6 MB L2.  float32 error on that snapshot: 2e-06 median, 9e-04 at p99.99, 2.5e-02 worst, concentrated
+on the densest sightlines -- it grows with the number of contributions summed, so smooth test problems
+understate it by ~3 orders of magnitude.
+
+The kernel compiles to 38 registers and zero local memory -- 100% occupancy -- because the walk is
+stackless: its entire state is one integer cursor threaded through NextBranch/FirstSubnode.
 
 Two things differ deliberately from the CPU walk:
 

--- a/src/pytreegrav/frontend.py
+++ b/src/pytreegrav/frontend.py
@@ -950,9 +950,11 @@ def ColumnDensity(
         per-target walk.
     device: str, optional
         'cpu' (default) or 'cuda'. 'cuda' needs pytreegrav[cuda] and an NVIDIA GPU, and applies only
-        to the ray-traced path (rays given, randomize_rays off). It is float32, so expect ~1e-5
-        relative error rather than the CPU path's 1e-15, and it repacks and uploads the tree on
-        every call -- for repeated evaluation hold a pytreegrav.cuda.CudaColumnDensity instead.
+        to the ray-traced path (rays given, randomize_rays off). It is float32: on a real STARFORGE
+        snapshot the relative error against this float64 path was 2e-6 median, 9e-4 at p99.99 and
+        2.5e-2 at worst, the largest errors falling on the densest sightlines. It also repacks and
+        uploads the tree on every call -- for repeated evaluation hold a
+        pytreegrav.cuda.CudaColumnDensity instead. Expect ~8x on clustered production data.
 
     Returns
     -------


### PR DESCRIPTION
Benchmarked against a STARFORGE snapshot (v1.0 M2e4_R10 Res271 snapshot_500, 24.7M gas particles, 6 rays, 148M walks) rather than only smooth synthetic clouds, and both published claims were optimistic.

Speedup is 7.94x, not the 11.8-18.2x the synthetic clouds gave: 106.7 s against 847.2 s on 32 Xeon Gold 6244 threads. Per-particle GPU cost rose 5.8x from N=3e6 synthetic to N=2.47e7 real while the CPU's rose 2.5x, for two reasons a Gaussian cloud cannot produce -- a 2.1 GB working set against a 6 MB L2, and 8.7e8 of dynamic range in column density putting dense-core and diffuse-gas sightlines in the same warp so lanes wait on each other. Docs now quote ~8x for production data.

float32 error is a distribution, not the ~1e-5 previously claimed. Over 12M sightlines: 2.0e-6 median, 4.4e-5 p99, 9.1e-4 p99.99, 2.5e-2 worst. It tracks column magnitude because error accumulates with the number of contributions summed, so the largest errors land on the densest sightlines -- 0.0091% of entries exceed 1e-3, with a median column 240x the overall median. Harmless in practice, since those are the sightlines where tau >> 1 anyway, but the smooth benchmarks understated the tail by three orders of magnitude.

Also records in experiments/gpu/README.md that both float32 hazards were checked on this data and are comfortable (span/h_min = 6.6e5 against ~1.7e7; max leaf prefactor 1.05e4 against 3.4e38), and that a 2M-target subsample's apparent 13.0x should be discarded as an artifact of striding the Morton order, which handicaps the CPU's grouped walk.