### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytreegrav"
-version = "1.3.0"
+version = "1.4.0"
 description = "Fast approximate gravitational force and potential calculations"
 readme = "README.md"
 authors = [{ name = "Mike Grudic", email = "mike.grudich@gmail.com" }]


### PR DESCRIPTION
Minor rather than patch, because 1.3.0 -> master added public API:

  TidalTensor, TidalTensorTarget, TidalKernel, and the brute-force and
  grouped-tree tidal solvers
  CudaPotential, CudaAccel, CudaPotentialBruteforce, CudaAccelBruteforce,
  and device="cuda" for method="bruteforce" (1.3.0 shipped only the column
  density backend)

Nothing here is a break. requires-python narrowed from >=3.6 to >=3.8, but no numba satisfying our own numba>=0.57 floor was ever installable on 3.6 or 3.7, so that only stops advertising an impossible install. src/pytreegrav/kdtree/ was deleted, but it had no __init__.py, so find_packages never picked it up and it was never in any wheel.

Verified from the built wheel in a clean venv: TidalTensor tree vs brute force 1.5e-04, tensor symmetric, TidalTensorTarget's trace in vacuum 2.8e-17 (Laplace), target tree matching brute force exactly at theta=0.1, and 223 passed / 32 skipped / 1 xfailed.