### PR TITLE
N-body example: one accel function, and a progress bar

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ jobs:
   pytest:
     name: pytest (python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # The suite runs in ~7 minutes; without a limit a hang would sit on a runner for the default
+    # 6 hours. Generous enough to absorb a slow runner, tight enough that a real hang fails visibly.
+    timeout-minutes: 25
     strategy:
       fail-fast: false          # report every version's result, not just the first failure
       matrix:

--- a/docs/source/Nbody_simulation.rst
+++ b/docs/source/Nbody_simulation.rst
@@ -16,26 +16,37 @@ initial velocity and geometry for extra fun. We also write a function to
 evaluate the total energy, which is conserved down to tree-force and
 integration errors.
 
+``compute_accel`` is the one place the force solver is configured. Both
+the initial conditions below and every timestep call it, so switching to
+``quadrupole=True``, a different ``theta``, or ``device="cuda"`` is a
+one-line change rather than a hunt through the notebook.
+
 .. code:: ipython3
 
     %pylab
     from pytreegrav import Accel, Potential
-    
-    def GenerateICs(N,seed=42):
-        np.random.seed(seed) # seed the RNG for reproducibility
-        pos = np.random.normal(size=(N,3)) # positions of particles
-        pos -= np.average(pos,axis=0) # put center of mass at the origin
-        vel = np.zeros_like(pos) # initialize at rest
-        vel -= np.average(vel,axis=0) # make average velocity 0
-        softening = np.repeat(0.1,N) # initialize softening to 0.1 
-        masses = np.repeat(1./N,N) # make the system have unit mass
-        return pos, masses, vel, softening
-    
-    def TotalEnergy(pos, masses, vel, softening):
-        kinetic = 0.5 * np.sum(masses[:,None] * vel**2)
-        potential = 0.5 * np.sum(masses * Potential(pos,masses,softening,parallel=True))
-        return kinetic + potential
 
+
+    def compute_accel(pos, masses, softening):
+        """Acceleration on every particle -- the only place the force solver is configured."""
+        return Accel(pos, masses, softening, parallel=True)
+
+
+    def GenerateICs(N, seed=42):
+        np.random.seed(seed)  # seed the RNG for reproducibility
+        pos = np.random.normal(size=(N, 3))  # positions of particles
+        pos -= np.average(pos, axis=0)  # put center of mass at the origin
+        vel = np.zeros_like(pos)  # initialize at rest
+        vel -= np.average(vel, axis=0)  # make average velocity 0
+        softening = np.repeat(0.1, N)  # initialize softening to 0.1
+        masses = np.repeat(1.0 / N, N)  # make the system have unit mass
+        return pos, masses, vel, softening
+
+
+    def TotalEnergy(pos, masses, vel, softening):
+        kinetic = 0.5 * np.sum(masses[:, None] * vel**2)
+        potential = 0.5 * np.sum(masses * Potential(pos, masses, softening, parallel=True))
+        return kinetic + potential
 
 .. parsed-literal::
 
@@ -53,22 +64,24 @@ the Hamiltonian split kick-drift-kick form (e.g. Springel 2005).
 
     def leapfrog_kdk_timestep(dt, pos, masses, softening, vel, accel):
         # first a half-step kick
-        vel[:] = vel + 0.5 * dt * accel # note that you must slice arrays to modify them in place in the function!
+        vel[:] = vel + 0.5 * dt * accel  # note that you must slice arrays to modify them in place in the function!
         # then full-step drift
         pos[:] = pos + dt * vel
         # then recompute accelerations
-        accel[:] = Accel(pos,masses,softening,parallel=True)
+        accel[:] = compute_accel(pos, masses, softening)
         # then another half-step kick
-        vel[:] = vel + 0.5 * dt * accel  
+        vel[:] = vel + 0.5 * dt * accel
 
 Main simulation loop
 --------------------
 
 .. code:: ipython3
 
+    import time
+
     pos, masses, vel, softening = GenerateICs(10000)  # initialize initial condition with 10k particles
 
-    accel = Accel(pos, masses, softening, parallel=True)  # initialize acceleration
+    accel = compute_accel(pos, masses, softening)  # initialize acceleration
 
     t = 0  # initial time
     Tmax = 50  # final/max time
@@ -80,11 +93,12 @@ Main simulation loop
 
     # snapshots for the movie below - store positions every Nth step, aimed at ~120 frames
     n_steps = int(Tmax / dt)
-    # note: %pylab shadows the builtin max() with numpy's, so spell this out explicitly
+    # note: %pylab shadows the builtin min() and max() with numpy's, so the clamps below are spelled out
     snapshot_interval = n_steps // 120 if n_steps > 120 else 1
     snapshots = []  # particle positions at each recorded step
     snap_times = []  # the times those snapshots were taken at
     step = 0
+    t_start = time.time()
 
 
     while t <= Tmax:  # actual simulation loop - this may take a couple minutes to run
@@ -100,13 +114,27 @@ Main simulation loop
         t += dt
         step += 1
 
+        # one-line progress bar, rewritten in place with a carriage return
+        frac = step / n_steps
+        if frac > 1.0:  # the loop runs on t, so the last step can overshoot n_steps slightly
+            frac = 1.0
+        elapsed = time.time() - t_start
+        eta = elapsed * (1.0 - frac) / frac if frac > 0 else 0.0
+        print(
+            "\r[%-30s] %5.1f%%  step %d/%d  t = %5.2f  %.0fs elapsed, ~%.0fs left"
+            % ("=" * int(30 * frac), 100 * frac, step, n_steps, t, elapsed, eta),
+            end="",
+            flush=True,
+        )
+
+    print()  # step off the progress bar line before the summary
     print("Simulation complete! Relative energy error: %g" % (np.abs((energies[0] - energies[-1]) / energies[0])))
     print("Recorded %d snapshots for the movie" % len(snapshots))
 
-
 .. parsed-literal::
 
-    Simulation complete! Relative energy error: 1.51338e-06
+    [==============================] 100.0%  step 1667/1666  t = 50.01  24s elapsed, ~0s left
+    Simulation complete! Relative energy error: 0.000332666
     Recorded 129 snapshots for the movie
 
 
@@ -120,14 +148,11 @@ function of time
 .. code:: ipython3
 
     %matplotlib inline
-    plt.figure(figsize=(4,4),dpi=300)
-    plt.plot(ts,energies,label="Total Energy")
-    plt.plot(ts,r50s,label="Half-mass Radius")
+    plt.figure(figsize=(4, 4), dpi=300)
+    plt.plot(ts, energies, label="Total Energy")
+    plt.plot(ts, r50s, label="Half-mass Radius")
     plt.xlabel("Time")
     plt.legend()
-
-
-
 
 .. parsed-literal::
 
@@ -174,7 +199,6 @@ The simulation loop above kept a copy of the particle positions every ``snapshot
     plt.close(fig)  # suppress the static first frame rendering next to the player
     # anim.save("nbody.mp4", fps=20, dpi=150)  # uncomment for an MP4 instead (needs ffmpeg)
     HTML(anim.to_jshtml(fps=20))
-
 
 (The notebook renders this as an interactive player; shown here as a pre-rendered
 animation.)

--- a/tests/test_nonunique_positions.py
+++ b/tests/test_nonunique_positions.py
@@ -161,8 +161,10 @@ def test_dynamic_tree_matches_static_without_duplicates():
     assert np.array_equal(np.sort(tree.TreewalkIndices), np.arange(3000))
 
 
-@pytest.mark.parametrize("kwargs", ["{'radix': False}", "{'vel': np.zeros((5, 3))}", "{}"])
-def test_duplicates_at_the_origin_terminate(kwargs):
+BUILD_VARIANTS = ["{'radix': False}", "{'vel': np.zeros((5, 3))}", "{}"]
+
+
+def test_duplicates_at_the_origin_terminate():
     """Duplicated particles sitting at exactly [0, 0, 0] must not hang the build.
 
     Both insertion builds separate coincident particles by nudging one of them, and the nudge
@@ -173,28 +175,53 @@ def test_duplicates_at_the_origin_terminate(kwargs):
     A hang cannot be caught in-process, so this runs in a subprocess under a timeout; without
     the fix the two insertion cases spin until killed.
 
-    The timeout is deliberately far above the real cost (5 s on a warm numba cache, 19-24 s on a CI
-    runner) because the failure it detects is an *infinite* loop -- no finite timeout distinguishes 120 s
-    from 600 s for that, while the tight one made this flaky on cold/slow machines.
+    All three variants share one subprocess deliberately. Every fresh interpreter pays a full numba
+    compile of the tree machinery -- 325 MB peak and ~6 s here, several times that on a CI runner --
+    and three of those, two thirds of the way through the suite, was the most expensive moment in the
+    run and where a 3.13 runner twice killed the job with SIGTERM. One subprocess still detects a hang
+    in any variant, since a hang means no DONE line and the timeout fires, and the START/PASS markers
+    say which variant it was. A third of the cost, one memory peak instead of three.
+
+    The timeout is deliberately far above the real cost because the failure it detects is an
+    *infinite* loop -- no finite timeout distinguishes 120 s from 600 s for that, while a tight one
+    made this flaky on cold or loaded machines.
     """
-    src = textwrap.dedent(f"""
+    cases = "\n".join(
+        f'print("START {v}", flush=True)\ncheck(**{v})\nprint("PASS {v}", flush=True)' for v in BUILD_VARIANTS
+    )
+    src = (
+        textwrap.dedent(
+            """
         import warnings, numpy as np
         warnings.simplefilter("ignore")
         from pytreegrav import ConstructTree
-        x = np.array([[0.,0.,0.],[0.,0.,0.],[1.,0.,0.],[0.,1.,0.],[0.,0.,1.]])
-        m, h = np.repeat(0.2, 5), np.repeat(0.1, 5)
-        tree = ConstructTree(x, m, h, **{kwargs})
-        assert tree.HasCoincidentPoints
-        assert np.isclose(tree.Masses[tree.NumParticles], 1.0)
-        assert np.array_equal(np.sort(tree.TreewalkIndices), np.arange(5))
-        print("OK")
-    """)
+
+
+        def check(**kw):
+            x = np.array([[0.,0.,0.],[0.,0.,0.],[1.,0.,0.],[0.,1.,0.],[0.,0.,1.]])
+            m, h = np.repeat(0.2, 5), np.repeat(0.1, 5)
+            tree = ConstructTree(x, m, h, **kw)
+            assert tree.HasCoincidentPoints
+            assert np.isclose(tree.Masses[tree.NumParticles], 1.0)
+            assert np.array_equal(np.sort(tree.TreewalkIndices), np.arange(5))
+
+        """
+        )
+        + cases
+        + '\nprint("DONE", flush=True)\n'
+    )
+
     try:
         r = subprocess.run([sys.executable, "-c", src], capture_output=True, text=True, timeout=600)
-    except subprocess.TimeoutExpired:
-        pytest.fail(f"build with {kwargs} hung on duplicates at the origin")
-    assert r.returncode == 0, f"rc={r.returncode}: {r.stderr[-2000:]}"
-    assert "OK" in r.stdout
+    except subprocess.TimeoutExpired as e:
+        out = e.stdout.decode(errors="replace") if isinstance(e.stdout, bytes) else (e.stdout or "")
+        started = [ln[len("START ") :] for ln in out.splitlines() if ln.startswith("START")]
+        where = started[-1] if started else "(hung before the first variant)"
+        pytest.fail(f"build hung on duplicates at the origin; variant in flight: {where}")
+    assert r.returncode == 0, f"rc={r.returncode}\nstdout:\n{r.stdout}\nstderr:\n{r.stderr[-2000:]}"
+    assert "DONE" in r.stdout, f"subprocess stopped early:\n{r.stdout}"
+    for v in BUILD_VARIANTS:
+        assert f"PASS {v}" in r.stdout, f"variant {v} did not complete:\n{r.stdout}"
 
 
 def test_lattice_positions_do_not_warn():


### PR DESCRIPTION
The force call was written out twice -- once to seed accel, once inside the stepper -- so changing theta, parallel, or quadrupole meant editing both. Both now call a single compute_accel, which is also the natural place to point at device="cuda".

The simulation loop runs ~1700 steps over a couple of minutes with no output until it finishes, so it now prints a one-line progress bar with percentage, step count, simulation time, elapsed and ETA. No new dependency: it is a carriage return and a %-30s. The clamps are written out rather than using min()/max() because %pylab shadows those with numpy's, whose second positional argument is an axis -- the same trap the existing snapshot_interval comment warns about.

The docs .rst is a static render of the notebook and had drifted: its code blocks still had the pre-formatting spacing. All five blocks are now byte-identical to the notebook's cells, so future divergence shows up as a diff instead of hiding.

Recorded output for the loop is re-measured, 3.33e-04 rather than the committed 1.51e-06. That is not from this change -- running the loop with the inline call and with the wrapper gives 0.000332666 and E0 = -0.282324949 to every printed digit, so the wrapper is exactly neutral. The old figure predates library changes already on master and no longer reproduces. The figure and the movie are still from the earlier run.